### PR TITLE
BusinessUnitTests - Trying to test the Board class

### DIFF
--- a/Pac-Man/Pac-Man.Business.UnitTests/BoardTests.cs
+++ b/Pac-Man/Pac-Man.Business.UnitTests/BoardTests.cs
@@ -1,0 +1,40 @@
+﻿using FakeItEasy;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using Pac_Man.Business;
+
+namespace Pac_Man.Business.UnitTests
+{
+    [TestClass]
+    public class BoardTests
+    {
+        private Board _board;
+        private IGameCharacters _gameCharacters;
+        public BoardTests() {
+            //Dependencies
+            _gameCharacters = A.Fake<IGameCharacters>();
+
+            //SUT
+            _board = new Board(_gameCharacters);
+        }
+
+        [TestMethod]
+        [DataRow("Clyde")]
+        //[DataRow("Pinky")]
+        //[DataRow("Inky")]
+        //[DataRow("Blinky")]
+        public void Board_CheckIfGhostSeesThePlayer_ReturnFalse(string ghostName)
+        {
+            //Arange
+            var keyValue = new KeyValuePair<int, int>(11, 12);
+            A.CallTo(() => _gameCharacters.Ghosts[ghostName].position).Returns(keyValue);
+
+            //Act
+            var result = _board.CheckIfGhostSeesThePlayer(ghostName);
+
+            //Assert
+
+            result.Should().BeFalse();
+        }
+    }
+}

--- a/Pac-Man/Pac-Man.Business.UnitTests/Pac-Man.Business.UnitTests.csproj
+++ b/Pac-Man/Pac-Man.Business.UnitTests/Pac-Man.Business.UnitTests.csproj
@@ -11,6 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="8.0.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />


### PR DESCRIPTION
So basically I am trying to do a test that should return false, because from their initial positions, the ghosts cannot see the pac-man.

The problem is, I mocked the interface, but the Board constructor (Board.cs ln: 20) has a board generator function that uses the interface  (Board.cs ln: 60),  but cannot use that because the interface is mocked, so the test unit function itself cannot be tested, receiving the following message when the GenerateTwelveRowSmall from BoardGenerator is called:

System.Collections.Generic.KeyNotFoundException: 'The given key 'Blinky' was not present in the dictionary.'

